### PR TITLE
Fix a typecasting problem

### DIFF
--- a/cochlea/zilany2014/_zilany2014.pyx
+++ b/cochlea/zilany2014/_zilany2014.pyx
@@ -242,7 +242,7 @@ def run_spike_generator(
     cdef double *synout_data = <double *>np.PyArray_DATA(synout)
 
     # Output spikes (signal)
-    sptimes = np.zeros(np.ceil(len(synout)/0.00075/fs))
+    sptimes = np.zeros(np.int_(np.ceil(len(synout)/0.00075/fs)))
     cdef double *sptimes_data = <double *>np.PyArray_DATA(sptimes)
 
 


### PR DESCRIPTION
The number of zeros have to be typecasted to int. Just using ceil is not
enough. (Numpy DeprecationWarning)