### PR TITLE
np.fft.fftpack deprecated

### DIFF
--- a/cochlea/zilany2014/__init__.py
+++ b/cochlea/zilany2014/__init__.py
@@ -117,8 +117,8 @@ def run_zilany2014(
     spike_trains = pd.DataFrame(list(trains))
 
 
-    if hasattr(np.fft, 'fftpack') and isinstance(np.fft.fftpack._fft_cache, dict):
-        np.fft.fftpack._fft_cache = {}
+    #if hasattr(np.fft, 'fftpack') and isinstance(np.fft.fftpack._fft_cache, dict):
+    #    np.fft.fftpack._fft_cache = {}
 
     return spike_trains
 


### PR DESCRIPTION
When trying to use on a newer Numpy version (2.x), the function fftpack is deprecated 

Newer version of Numpy do not support this function anymore, and the cochlea package dont use it.